### PR TITLE
Build Ruby runtimes for ubuntu-20.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-16.04, ubuntu-18.04, macos-latest ]
+        os: [ ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, macos-latest ]
         ruby: [ "truffleruby-20.1.0" ]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
There is a new experimental GH action environment for [`ubuntu-20.04` that was just added 5 days ago](https://github.com/actions/virtual-environments/issues/228) and this PR adds Ruby downloadable runtimes to the releases.