### PR TITLE
Support Ruby 1.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
         if [ ! -e $PREFIX/bin/bundle ]; then
           export PATH="$PREFIX/bin:$PATH"
           if [[ "${{ matrix.ruby }}" == ruby-1.9* ]]; then
-            gem install bundler -v '~>1'
+            gem install bundler -v '~> 1' --no-ri --no-rdoc
           else
             gem install bundler -v '~> 1' --no-document
           fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Install JSON gem
       run: |
         if [[ "${{ matrix.ruby }}" == ruby-1.9* ]]; then
-          gem install json -v '2.2.0'
+          gem install json -v '2.2.0' --no-ri --no-rdoc
         else
           gem install json -v '2.2.0' --no-document
         fi


### PR DESCRIPTION
Support building Ruby 1.9. Uses an appropriate OpenSSL version and removes usage of --no-document as it wasn't supported.

See https://github.com/ruby/setup-ruby/issues/204

Build succeeded, but CI failed on `Error: request to https://uploads.github.com/repos/ruby/ruby-builder/releases/33599578/assets?name=ruby-1.9.3-p551-ubuntu-18.04.tar.gz& failed, reason: socket hang up` which is likely permissions related.