### PR TITLE
Build ruby-3.1.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-18.04, ubuntu-20.04, macos-10.15 ]
-        ruby: [jruby-9.3.2.0]
+        ruby: [ruby-3.1.0]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
@@ -120,7 +120,7 @@ jobs:
         asset_content_type: application/gzip
 
   buildJRubyWindows:
-    if: true
+    if: false
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
We can build Ruby 3.1.0 via rbenv 🎉 
https://github.com/rbenv/ruby-build/releases/tag/v20211225