### PR TITLE
Fix windows builds

### DIFF
--- a/.github/workflows/check-new-windows-versions.yml
+++ b/.github/workflows/check-new-windows-versions.yml
@@ -28,6 +28,6 @@ jobs:
     - if: ${{ steps.diff.outcome == 'failure' }} # changed
       uses: ruby/ruby-builder/.github/actions/create-pr-to-setup-ruby@master
       with:
-        version: windows
+        versions: windows
         title: Update CRuby releases on Windows
         token: ${{ secrets.CHECK_NEW_RELEASES_TOKEN }}


### PR DESCRIPTION
Windows builds have been failing due to a typo in CI definition. It is causing `2.7.7`, `3.0.5`, `3.1.3` builds to be missing.

https://github.com/ruby/ruby-builder/actions/runs/3747130715/jobs/6363065375

> Warning: Unexpected input(s) 'version', valid inputs are ['versions', 'token', 'title']