### PR TITLE
Removed macos-10.15 because it will be removed at 2023-03-31

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, macos-10.15 ]
+        os: [ ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, macos-11 ]
         ruby: [ruby-3.2.1]
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Archives are named `$engine-$version-$platform.tar.gz`.
 
 `platform` is one of:
 * `ubuntu-NN.NN`: built on the corresponding GitHub-hosted runner virtual environment
-* `macos-latest`: built on `macos-10.15` (the oldest `macos` available on GitHub-hosted runners)
+* `macos-latest`: built on `macos-11` (the oldest `macos` available on GitHub-hosted runners)
 * `windows-latest`: built on `windows-2019` (does not matter, it's only for repacking a JRuby archive, no actual build)
 
 The names contain `-latest` for compatibility, even though what `-latest` points to for runners might have changed.


### PR DESCRIPTION
This is part of https://github.com/ruby/setup-ruby/pull/467