### PR TITLE
Support building multiple JRuby versions at once

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,8 +129,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-        - { os: windows-2019, jruby-version: 9.4.4.0 }
+        os: [ windows-2019 ]
+        jruby-version: [ 9.4.4.0 ]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/build.rb
+++ b/build.rb
@@ -21,8 +21,7 @@ raise unless unix && windows
 
 unix.sub!(/ruby: .+/, "ruby: [#{versions.join(', ')}]")
 if jruby
-  raise "More than 1 version not supported for JRuby" unless versions.size == 1
-  windows.sub!(/jruby-version: .+/, "jruby-version: #{versions.first.delete_prefix('jruby-')} }")
+  windows.sub!(/jruby-version: .+/, "jruby-version: [#{versions.map { |v| v.delete_prefix('jruby-') }.join(', ')}]")
 end
 
 if_lines = lines.select { |line| line.match?(/^    if: (true|false)/) }


### PR DESCRIPTION
A build failed because two new JRuby versions were detected - https://github.com/ruby/ruby-builder/actions/runs/6767356671/job/18389860064.

I checked the `build.yml` file history and couldn't find why multiple JRuby versions could not be provided.