### PR TITLE
Build Ruby 3.3.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-20.04, ubuntu-22.04, macos-11, macos-arm-oss ]
-        ruby: [ruby-3.3.0-rc1]
+        ruby: [ruby-3.3.0]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Ruby 3.3.0 has been [released today](https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/), if I understand correctly we need this to generate a PR so that it's available in GitHub Actions through https://github.com/ruby/setup-ruby

Thanks!