### PR TITLE
Update Intel/amd64 runner from `macos-12` to `macos-13` due to deprecation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-12, macos-14 ]
+        os: [ ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-13, macos-14 ]
         ruby: [jruby-9.4.9.0]
     runs-on: ${{ matrix.os }}
     steps:
@@ -24,7 +24,7 @@ jobs:
       id: platform
       run: |
         platform=${{ matrix.os }}
-        platform=${platform/macos-12/macos-latest}
+        platform=${platform/macos-13/macos-latest}
         platform=${platform/macos-14/macos-13-arm64}
         echo "platform=$platform" >> $GITHUB_OUTPUT
     - name: Set ruby

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Archives are named `$engine-$version-$platform.tar.gz`.
 
 `platform` is one of:
 * `ubuntu-NN.NN`: built on the corresponding GitHub-hosted runner virtual environment
-* `macos-latest`: built on `macos-12`, the oldest `macos-amd64` available on GitHub-hosted runners.
+* `macos-latest`: built on `macos-13`, the oldest `macos-amd64` available on GitHub-hosted runners.
 * `macos-13-arm64`: built on `macos-14`, the oldest `macos-arm64` available on GitHub-hosted runners.
 * `windows-latest`: built on `windows-2019` (does not matter, it's only for repacking a JRuby archive, no actual build)
 


### PR DESCRIPTION
Reasoning: https://github.com/actions/runner-images/issues/10721