### PR TITLE
Install JDK 21 for JRuby 10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,11 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu') && startsWith(steps.ruby.outputs.ruby, 'ruby-')
     - run: sudo apt-get install -y --no-install-recommends libyaml-dev
       if: startsWith(matrix.os, 'ubuntu') && startsWith(steps.ruby.outputs.ruby, 'truffleruby')
+    - uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: 21
+      if: startsWith(steps.ruby.outputs.ruby, 'jruby-')
 
     - name: Install system ruby for ruby-2.5.2
       run: sudo apt-get install -y --no-install-recommends ruby
@@ -153,6 +158,11 @@ jobs:
     - name: Check if already built
       run: '! curl -s -L --head --fail https://github.com/ruby/ruby-builder/releases/download/${{ steps.info.outputs.tag }}/${{ steps.ruby.outputs.archive }}'
       shell: bash
+
+    - uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: 21
 
     - name: Set PREFIX
       run: echo "PREFIX=$HOME/.rubies/${{ steps.ruby.outputs.ruby }}" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu') && startsWith(steps.ruby.outputs.ruby, 'ruby-')
     - run: sudo apt-get install -y --no-install-recommends libyaml-dev
       if: startsWith(matrix.os, 'ubuntu') && startsWith(steps.ruby.outputs.ruby, 'truffleruby')
-    - run: echo "JAVA_HOME=${JAVA_HOME_21_X64:-${JAVA_HOME_21_arm64:-}}" > "$GITHUB_ENV"
+    - run: echo "JAVA_HOME=${JAVA_HOME_21_X64:-${JAVA_HOME_21_arm64:-}}" >> "$GITHUB_ENV"
       if: startsWith(steps.ruby.outputs.ruby, 'jruby-')
 
     - name: Install system ruby for ruby-2.5.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,10 +61,7 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu') && startsWith(steps.ruby.outputs.ruby, 'ruby-')
     - run: sudo apt-get install -y --no-install-recommends libyaml-dev
       if: startsWith(matrix.os, 'ubuntu') && startsWith(steps.ruby.outputs.ruby, 'truffleruby')
-    - uses: actions/setup-java@v4
-      with:
-        distribution: temurin
-        java-version: 21
+    - run: echo "JAVA_HOME=${JAVA_HOME_21_X64:-${JAVA_HOME_21_arm64:-}}" > "$GITHUB_ENV"
       if: startsWith(steps.ruby.outputs.ruby, 'jruby-')
 
     - name: Install system ruby for ruby-2.5.2
@@ -159,10 +156,8 @@ jobs:
       run: '! curl -s -L --head --fail https://github.com/ruby/ruby-builder/releases/download/${{ steps.info.outputs.tag }}/${{ steps.ruby.outputs.archive }}'
       shell: bash
 
-    - uses: actions/setup-java@v4
-      with:
-        distribution: temurin
-        java-version: 21
+    - run: echo "JAVA_HOME=${JAVA_HOME_21_X64:-${JAVA_HOME_21_arm64:-}}" > "$GITHUB_ENV"
+      shell: bash
 
     - name: Set PREFIX
       run: echo "PREFIX=$HOME/.rubies/${{ steps.ruby.outputs.ruby }}" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,7 +156,7 @@ jobs:
       run: '! curl -s -L --head --fail https://github.com/ruby/ruby-builder/releases/download/${{ steps.info.outputs.tag }}/${{ steps.ruby.outputs.archive }}'
       shell: bash
 
-    - run: echo "JAVA_HOME=${JAVA_HOME_21_X64:-${JAVA_HOME_21_arm64:-}}" > "$GITHUB_ENV"
+    - run: echo "JAVA_HOME=${JAVA_HOME_21_X64:-${JAVA_HOME_21_arm64:-}}" >> "$GITHUB_ENV"
       shell: bash
 
     - name: Set PREFIX


### PR DESCRIPTION
This PR fixes the broken builds of jruby-10.0.0.0 due to inconsistent default JDK version on different runners.