### PR TITLE
Add platform normalization for windows-11-arm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,7 +142,8 @@ jobs:
       id: platform
       run: |
         platform=${{ matrix.os }}
-        platform=${platform/windows-*/windows-latest}
+        platform=${platform/windows-2019/windows-latest}
+        platform=${platform/windows-11-arm/windows-arm64}
         echo "platform=$platform" >> $GITHUB_OUTPUT
       shell: bash
     - name: Set ruby


### PR DESCRIPTION
JRuby >=9.4.4.0 supports windows on arm: https://github.com/jruby/jruby/releases/tag/9.4.4.0

GitHub Actions recently added new windows-11-arm runner for OSS: https://github.blog/changelog/2025-04-14-windows-arm64-hosted-runners-now-available-in-public-preview/

Name `windows-11-arm` is normalized to `windows-11-arm64` to align similar to how ubuntu and mac runner's names get normalized.